### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build   # uses the “build” script in package.json
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-genaiglobal.org

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+genaiglobal.org

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: '/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and publish the Vite site to GitHub Pages
- move custom-domain CNAME into `public/` so it's included in the build
- set an explicit base path in `vite.config.ts` for correct asset URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a545eb497c832eb2909961708ad2f1